### PR TITLE
Fix matrix rotate generics bug

### DIFF
--- a/glm/mat_transform.nim
+++ b/glm/mat_transform.nim
@@ -15,7 +15,7 @@ proc rotate*[T](m:Mat4x4[T], axis:Vec3[T], angle:T):Mat4x4[T]=
         s = sin(a)
     var 
         naxis = normalize(axis)
-        temp  = (1.T - c) * naxis
+        temp  = T(1 - c) * naxis
         Rotate = mat4(0.0);
 
     Rotate[0][0] = c + temp[0] * axis[0];


### PR DESCRIPTION
The following would not compile without this fix (tested with Nim 0.13.0):

```
let
  normal = vec3[float32](0.0, 0.0, 1.0)

var m = mat4x4[float32](1.0)
m = m.rotate(normal, 1.0)
```
