### PR TITLE
Rename all addr methods to caddr (addr must not be overloaded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Nim-glm has vector constructors:
 Here's some examples
 
-    var 
+    var
         v = vec3(1.0, 5.0, 6.0)
         a = vec3(2.0, 2.0, 5.0)
         v4 = vec4(v, 1.0);
@@ -25,6 +25,6 @@ Also, this version has basics for common matrices creations:
 
 Use it in OpenGL environment:
 
-    glUniformMatrix4fv(_uniformLocation, 1, false, projectionMatrix.addr)
+    glUniformMatrix4fv(_uniformLocation, 1, false, projectionMatrix.caddr)
 
 

--- a/glm/macros/matrix.nim
+++ b/glm/macros/matrix.nim
@@ -2,7 +2,7 @@ import macros, strutils
 
 template macroInit(m,M:expr){.immediate.}=
   result = newNimNode(nnkStmtList);
-  var 
+  var
     m = minSize.intVal.int
     M = maxSize.intVal.int
 
@@ -22,7 +22,7 @@ macro matrixEchos*(minSize, maxSize:int):stmt=
 
 macro addrGetter*(minSize, maxSize:int):stmt=
   macroInit(m, M)
-  let procT = "proc addr*[T](m:var Mat$1x$2[T]):ptr T= array[$1, array[$2,T]](m)[0][0].addr"
+  let procT = "proc caddr*[T](m:var Mat$1x$2[T]):ptr T= array[$1, array[$2,T]](m)[0][0].addr"
   for col in m..M:
     for row in m .. M:
       var def = procT % [ $col, $row]
@@ -38,7 +38,7 @@ macro columnGetters*(minSize, maxSize:int):stmt=
       var def2 = procTvar % [ $col, $row]
       result.add(parseStmt(def1))
       result.add(parseStmt(def2))
-      
+
 macro columnSetters*(minSize, maxSize:int):stmt=
   macroInit(m, M)
   let procT = "proc `[]=`*[T](m:var Mat$1x$2[T], ix:int, c:Vec$2[T])= array[$1, Vec$2[T]](m)[ix] = c"
@@ -50,7 +50,7 @@ macro columnSetters*(minSize, maxSize:int):stmt=
 macro matrixScalarOperations*(minSize, maxSize:int):stmt=
   macroInit(m, M)
   let procT = "proc `$3`*[T](m:Mat$1x$2[T], s:T):Mat$1x$2[T]=" &
-         "Mat$1x$2(map(array[$1,Vec$2[T]](m),proc(v:Vec$2[T]):Vec$2[T]= v $3 s))" 
+         "Mat$1x$2(map(array[$1,Vec$2[T]](m),proc(v:Vec$2[T]):Vec$2[T]= v $3 s))"
   for op in ["+", "-", "*", "/"]:
     for col in m..M:
       for row in m .. M:
@@ -61,7 +61,7 @@ macro matrixUnaryScalarOperations*(minSize, maxSize:int):stmt=
   macroInit(m,M)
   let opT = "  m[$1][$2]= m[$1][$2] $3  s"
   let T = "proc `$3=`*[T](m:var Mat$1x$2[T], s:T)=\n  var a = array[$1,array[$2,T]](m)\n"
-  
+
   for op in ["+", "-", "*", "/"]:
     for col in m..M:
       for row in m..M:
@@ -101,8 +101,8 @@ macro matrixConstructors*(minSize, maxSize:int):stmt=
 
 macro diagonalConstructors*(minSize,maxSize:int):stmt=
   macroInit(m, M)
-  let T = "proc mat$1x$2*[T](s:T):Mat$1x$2[T]=mat$1x$2($3)"  
-  let Tt = "proc mat$1*[T](s:T):Mat$1x$2[T]=mat$1x$2($3)"  
+  let T = "proc mat$1x$2*[T](s:T):Mat$1x$2[T]=mat$1x$2($3)"
+  let Tt = "proc mat$1*[T](s:T):Mat$1x$2[T]=mat$1x$2($3)"
   var vT = "vec$1($2)"
   for col in m..M:
     for row in m..M:
@@ -120,7 +120,7 @@ macro diagonalConstructors*(minSize,maxSize:int):stmt=
 
 macro emptyConstructors*(minSize, maxSize:int):stmt=
   macroInit(m,M)
-  let vecTemplate = "vec$1($2)" 
+  let vecTemplate = "vec$1($2)"
   let fullTemplate= "proc mat$1x$2*():Mat$1x$2[float]=mat$1x$2($3)"
   let partialTemplate= "proc mat$1*():Mat$1x$2[float]=mat$1($3)"
   for col in m..M:
@@ -175,7 +175,7 @@ macro matrixMultiplication*(minSize, maxSize:int):stmt=
       if l.r == r.c:
         var def = Template % [$l.c, $l.r, $r.r]
         result.add(parseStmt( def ));
-      
+
 macro matrixVectorMultiplication*(minSize, maxSize:int):stmt=
   macroInit(m,M)
   let Tv = "proc `*`*[T](m:Mat$1x$2[T], v:Vec$1[T]):Vec$2[T]=Vec$2(matVecProduct( array[$1,array[$2,T]](m), array[$1,T](v)))"

--- a/glm/macros/vector.nim
+++ b/glm/macros/vector.nim
@@ -65,7 +65,7 @@ macro arrGetters*(upTo:int):stmt=
 
 macro addrGetter*(upTo:int):stmt=
     var upToVec = intVal(upTo)
-    let procT = """proc addr*[T](v:var Vec$1[T]):ptr T= 
+    let procT = """proc caddr*[T](v:var Vec$1[T]):ptr T=
         ## Address getter to pass vector to native-C openGL functions as pointers
         array[$1, T](v)[0].addr"""
     result = newNimNode(nnkStmtList);
@@ -87,7 +87,7 @@ macro componentGetterSetters*(upTo:int):stmt=
                 result.add(parseStmt( templG % [tr[i], $s, $i] ))
                 result.add(parseStmt( templS % [col[i], $s, $i] ))
                 result.add(parseStmt( templG % [col[i], $s, $i] ))
-    
+
 proc pow(a,b:int):int= floor(pow(a.float, b.float)).int
 proc fmod(a,b:int):int=floor(fmod(a.float, b.float)).int
 iterator shifts(minArr,arrLen,upToVec:int):seq[int]=
@@ -113,16 +113,16 @@ macro multiComponentGetterList*(upTo:int):stmt=
             var procStr = "proc $1*[T](v: Vec$2[T]):Vec$3[T]=Vec$3[T]([$4])" % [getter.join(""), $i, $combination.len, arr.join(",")]
             result.add(parseStmt( procStr))
 
-        
+
 proc getComponentIx(shiftn,length,componentIx:int):int=
     floor(shiftn.fmod( pow(length,componentIx) )/pow(length,componentIx-1) ).int
-    
+
 proc shifts(data:seq[char]):seq[seq[char]]=
-    
+
     var length = data.len;
     var shifts = pow(length, length)
     result = @[]
-    
+
     for i in 0..shifts-1:
         var cs:seq[char] = @[]
         for j in 1..length:
@@ -214,7 +214,7 @@ macro createConstructors*(upTo:int):stmt =
 
 proc `*`*[T](a:var array[3,T], s:T)=
     for i in 0..2: a[i] *= s
-    
+
 
 macro createScalarOperations*(upTo:int):stmt=
     let upToVec = intVal(upTo).int


### PR DESCRIPTION
This has caused me a considerable grief, as overloading addr _sometimes_ works, and _sometimes_ doesn't. Not your fault though, it's not mentioned in the manual and it should raise a compiler error anyway...

Here's Araq's comment that `addr` must not be overloaded:

https://github.com/nim-lang/Nim/issues/4007#issuecomment-202836745
