### PR TITLE
Add inline pragma to some vector methods

### DIFF
--- a/glm/macros/vector.nim
+++ b/glm/macros/vector.nim
@@ -55,17 +55,17 @@ macro arrSetters*(upTo:int):stmt=
     var upToVec = intVal(upTo)
     result = newNimNode(nnkStmtList)
     for i in 1..upToVec:
-        result.add(parseStmt("proc `[]=`*[T](v:var Vec$1[T], ix:int, c:T) = array[$1,T](v)[ix]=c" % [$i] ))
+        result.add(parseStmt("proc `[]=`*[T](v:var Vec$1[T], ix:int, c:T) {.inline.} = array[$1,T](v)[ix]=c" % [$i] ))
 
 macro arrGetters*(upTo:int):stmt=
     var upToVec = intVal(upTo)
     result = newNimNode(nnkStmtList)
     for i in 1..upToVec:
-        result.add(parseStmt("proc `[]`*[T](v:Vec$1[T], ix:int):T = array[$1,T](v)[ix]" % [$i] ))
+        result.add(parseStmt("proc `[]`*[T](v:Vec$1[T], ix:int):T {.inline.} = array[$1,T](v)[ix]" % [$i] ))
 
 macro addrGetter*(upTo:int):stmt=
     var upToVec = intVal(upTo)
-    let procT = """proc caddr*[T](v:var Vec$1[T]):ptr T=
+    let procT = """proc caddr*[T](v:var Vec$1[T]):ptr T {.inline.} =
         ## Address getter to pass vector to native-C openGL functions as pointers
         array[$1, T](v)[0].addr"""
     result = newNimNode(nnkStmtList)
@@ -76,8 +76,8 @@ macro addrGetter*(upTo:int):stmt=
 macro componentGetterSetters*(upTo:int):stmt=
     var upToVec = intVal(upTo)
     result = newNimNode(nnkStmtList)
-    let templG = "proc $1*[T](v:Vec$2[T]):T=array[$2,T](v)[$3]"
-    let templS = "proc `$1=`*[T](v:var Vec$2[T],c:T)=(array[$2,T](v))[$3]=c"
+    let templG = "proc $1*[T](v:Vec$2[T]):T {.inline.} =array[$2,T](v)[$3]"
+    let templS = "proc `$1=`*[T](v:var Vec$2[T],c:T) {.inline.} =(array[$2,T](v))[$3]=c"
     let tr = ["x","y","z","w"]
     let col= ["r","g","b","a"]
     for i in low(tr)..high(tr):


### PR DESCRIPTION
Vector setters and getters do not get inlined by the C compiler, which results in suboptimal performance in tight loops (~5x speed decrease, tested with gcc and clang on OS X, Linux & Windows).

This fix inlines the vector setters and getters, and a few other methods that would benefit from inlining and are cheap to inline.

Example benchmark (it is important to compile with `-d:release`!):
https://gist.github.com/johnnovak/a1bcaeeb0086c797cf03201d15a3f902

Sample results:
- gcc (Debian 4.9.2-10) 4.9.2
- Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz

Without inlineing:

```
Total time: 33.46370792388916s
Millions of intersections per second: 29.88312001390968
```

With inlineing:

```
Total time: 0.5918810367584229s
Millions of intersections per second: 168.9528702383738
```

EDIT: Don't get confused about the total time... The first test was run 1 billion times and the second just 100 million... The intersections per second value counts.
