### PR TITLE
Fix building documentation for vec.nim and mat.nim

### DIFF
--- a/glm/mat.nim
+++ b/glm/mat.nim
@@ -57,9 +57,7 @@ proc `[]`*[M,N,T](v: var Mat[M,N,T]; ix, iy: int): var T {.inline.} =
 
 proc caddr*[M,N,T](m: var Mat[M,N,T]): ptr T = m.arr[0].arr[0].addr
 
-##############
-# type alias #
-##############
+# type alias
 
 type
   Mat4x4*[T] = Mat[4,4,T]
@@ -90,9 +88,7 @@ proc diag*[N,T](v : Vec[N,T]): Mat[N,N,T] =
   for i in 0 ..< N:
     result.arr[i].arr[i] = v.arr[i]
 
-####################
-# type constructor #
-####################
+# type constructor
 
 # generic
 proc mat4*[T](a,b,c,d: Vec4[T]) : Mat4[T] =

--- a/glm/vec.nim
+++ b/glm/vec.nim
@@ -132,9 +132,7 @@ proc `[]`*[N,T](v: Vec[N,T]; ix: int): T {.inline.} =
 proc `[]`*[N,T](v: var Vec[N,T]; ix: int): var T {.inline.} =
   v.arr[ix]
 
-#########################
-# constructor functions #
-#########################
+# constructor functions
 
 proc vec4*[T](x,y,z,w:T)         : Vec4[T] {.inline.} = Vec4[T](arr: [  x,   y,   z,   w])
 proc vec4*[T](v:Vec3[T],w:T)     : Vec4[T] {.inline.} = Vec4[T](arr: [v.x, v.y, v.z,   w])
@@ -262,9 +260,7 @@ proc caddr*[N,T](v:var Vec[N,T]): ptr T {.inline.}=
   ## Address getter to pass vector to native-C openGL functions as pointers
   v.arr[0].addr
 
-####################################
-# Angle and Trigonometry Functions #
-####################################
+# Angle and Trigonometry Functions
 
 template foreachImpl(fun: untyped): untyped =
   proc fun*[N,T](v: Vec[N,T]): Vec[N,T] =
@@ -303,9 +299,7 @@ proc degrees*(v : SomeFloat): SomeFloat {.inline.} =
 foreachImpl(radians)
 foreachImpl(degrees)
 
-#########################
-# Exponential Functions #
-#########################
+# Exponential Functions
 
 export math.pow
 
@@ -322,9 +316,7 @@ foreachImpl(ln)
 foreachImpl(log2)
 foreachImpl(sqrt)
 
-####################
-# common functions #
-####################
+# common functions
 
 export math.ceil, math.floor, math.round
 
@@ -451,9 +443,7 @@ proc step*[N,T](edge: T; x: Vec[N,T]): Vec[N,T] =
     result.arr[i] = T(x.arr[i] >= edge)
 
 
-#######################
-# Geometric Functions #
-#######################
+# Geometric Functions
 
 proc dot*[N,T](u,v: Vec[N,T]): T {. inline .} =
   # TODO this really should have some simd optimization
@@ -485,9 +475,7 @@ proc refract*[N,T](i,n: Vec[N,T]; eta: T): Vec[N,T] =
   if k >= 0.0:
     result = eta * i - (eta * dot(n, i) + sqrt(k)) * n;
 
-###################
-# more type names #
-###################
+# more type names
 
 type
   Vec4u8* = Vec[4, uint8]


### PR DESCRIPTION
Right now building documentation for nim-glm gives the following errors:

```
/tmp/nim-glm/glm/vec.nim(135, 1) Error: new section expected
/tmp/nim-glm/glm/mat.nim(60, 1) Error: new section expected
```

These errors in turn cause other many other errors in the other modules.

The cause of the errors seem to be these box style comments. Simplifying them seems to fix the issue.

The command I used to generate the docs is `nim doc --project glm.nim`.