### PR TITLE
removed radians/degrees, replaced with math.radToDeg and math.degToRad

### DIFF
--- a/glm/vec.nim
+++ b/glm/vec.nim
@@ -310,14 +310,8 @@ foreachImpl(sinh)
 foreachImpl(cosh)
 foreachImpl(tanh)
 
-proc radians*(v : SomeFloat): SomeFloat {.inline, noinit.} =
-  v * math.Pi / 180
-
-proc degrees*(v : SomeFloat): SomeFloat {.inline, noinit.} =
-  v * 180 / math.Pi
-
-foreachImpl(radians)
-foreachImpl(degrees)
+foreachImpl(radToDeg)
+foreachImpl(degToRad)
 
 # Exponential Functions
 


### PR DESCRIPTION
The stdlib already has those procedures built into the `math` module. The names `radians` and `degrees` don't tell you what you're converting from, and that makes code less readable. Also, it makes type-safe unit wrappers not really possible. Here's part of a module I wrote a while ago:
```nim
import std/math

type
  Radians* = distinct float32
  Degrees* = distinct float32

proc `$`*(radians: Radians): string = $radians.float32 & " rad"
proc `$`*(degrees: Degrees): string = $degrees.float32 & "°"

func radians*(value: float32): Radians =
  ## Marks a float value as radians.
  value.Radians

func degrees*(value: float32): Degrees =
  ## Marks a float value as degrees.
  value.Degrees

converter toRadians*(degrees: Degrees): Radians =
  ## Converter from degrees to radians.
  radians(degrees.float32.degToRad)

converter toDegrees*(radians: Radians): Degrees =
  ## Converter from radians to degrees.
  degrees(radians.float32.radToDeg)
```
Nim's overloading resolution chose glm's `radians` over my `radians`, which caused a weird bug that took me a while to solve.

Also, could you please create a new release? It's been a while since the last release, when I pulled #head my other code which uses nim-glm was already broken (though fortunately it was a simple fix).