### PR TITLE
Added 8-bit and 16-bit int vec types

### DIFF
--- a/glm/vec.nim
+++ b/glm/vec.nim
@@ -538,8 +538,12 @@ template vecGen(U:untyped,V:typed) =
 
 vecGen f, float32
 vecGen d, float64
+vecGen i8, int8
+vecGen i16, int16
 vecGen i, int32
 vecGen l, int64
+vecGen ui8, uint8
+vecGen ui16, uint16
 vecGen ui, uint32
 vecGen ul, uint64
 vecGen b, bool


### PR DESCRIPTION
These are useful for 2d/3d grid based systems, e.g. a position within a minecraft voxel chunk only requires a vec3ui8

Once you've got a couple entities you start to see real cache performance improvements if you're shrinking your vector type by 4x